### PR TITLE
Add README docs and MIT license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 tenderpanini
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,68 @@
+# Symfony Monolight Bundle
+
+Symfony Monolight is a Symfony bundle that simplifies the management and display of application logs. It provides a console command to view logs from different directories configured in your project.
+
+## Installation
+
+Follow these steps to add the bundle to your project:
+
+1. **Install with Composer**
+
+   ```bash
+   composer require tenderpanini/symfony-monolight
+   ```
+
+2. **Register the Bundle**
+
+   Add the bundle class to your `config/bundles.php` file:
+
+   ```php
+   // config/bundles.php
+   return [
+       // ...
+       TenderPanini\SymfonyMonolight\SymfonyMonolight::class => ['all' => true],
+   ];
+   ```
+
+3. **Configure**
+
+   Create a new file named `symfony_monolight.yaml` inside `config/packages` and add the default configuration:
+
+   ```yaml
+   # config/packages/symfony_monolight.yaml
+   symfony_monolight:
+     default:
+       key: 'default'
+       log_directory: '%kernel.logs_dir%'
+       log_pattern: 'dev.log'
+     custom:
+       - key: 'custom1'
+         log_directory: '%kernel.logs_dir%/custom1'
+         log_pattern: 'custom1.log'
+       - key: 'custom2'
+         log_directory: '%kernel.logs_dir%/custom2'
+         log_pattern: 'custom2.log'
+     in_use: 'default'
+   ```
+
+   Adjust the `custom` entries as needed and set `in_use` to the configuration key you wish to use.
+
+4. **Clear the Cache**
+
+   ```bash
+   php bin/console cache:clear
+   ```
+
+## Usage
+
+Once installed and configured, you can read your logs using the provided command:
+
+```bash
+php bin/console monolight:logs
+```
+
+The command prints a formatted list of log entries from the directory configured in `symfony_monolight.yaml`.
+
+## License
+
+This project is released under the MIT License. See the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
## Summary
- document installation and usage in README
- add MIT license text

## Testing
- `make stan` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841ee681e7c832d86aeaca7e14648d1