### PR TITLE
Add php-cs-fixer and rector checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,5 +20,9 @@ jobs:
           php composer-setup.php --quiet --install-dir=/usr/local/bin --filename=composer
           rm composer-setup.php
           composer install --no-interaction --no-progress
+      - name: Run PHP-CS-Fixer
+        run: vendor/bin/php-cs-fixer fix --dry-run --diff
+      - name: Run Rector
+        run: vendor/bin/rector process --dry-run
       - name: Run PHPUnit
         run: vendor/bin/phpunit

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,13 @@
+<?php
+
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__.'/src')
+    ->in(__DIR__.'/tests');
+
+return (new PhpCsFixer\Config())
+    ->setRules([
+        '@PSR12' => true,
+        'array_syntax' => ['syntax' => 'short'],
+    ])
+    ->setFinder($finder);
+

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
     "require-dev": {
         "phpunit/phpunit": "*",
         "phpstan/phpstan": "^1.10",
-        "phpstan/phpstan-symfony": "^1.3"
+        "phpstan/phpstan-symfony": "^1.3",
+        "friendsofphp/php-cs-fixer": "^3.44",
+        "rector/rector": "^0.17.0"
     },
     "license": "MIT",
     "autoload": {

--- a/rector.php
+++ b/rector.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use Rector\Config\RectorConfig;
+use Rector\Set\ValueObject\LevelSetList;
+
+return static function (RectorConfig $rectorConfig): void {
+    $rectorConfig->paths([
+        __DIR__.'/src',
+    ]);
+
+    $rectorConfig->sets([
+        LevelSetList::UP_TO_PHP_82,
+    ]);
+};
+


### PR DESCRIPTION
## Summary
- require php-cs-fixer and rector in composer dev dependencies
- add configuration files for php-cs-fixer and rector
- run php-cs-fixer and rector during CI

## Testing
- `composer install` *(fails: command not found)*
- `vendor/bin/phpunit` *(fails: no such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_6841ebf05e0c832d9337510fca0125b3